### PR TITLE
Make anchors compatible with ruamel.yaml >= 0.18.7

### DIFF
--- a/ccorp/ruamel/yaml/include/__init__.py
+++ b/ccorp/ruamel/yaml/include/__init__.py
@@ -106,7 +106,9 @@ def include_compositor(self, anchor):
     yaml = self.loader.fork()
     path = os.path.join(os.path.dirname(self.loader.reader.name), event.value)
     with open(os.path.abspath(path)) as f:
-        return yaml.compose(f)
+        rv = yaml.compose(f)
+        self.loader.composer.anchors.update(yaml.composer.anchors)
+        return rv
 
 
 def exclude_filter(key_node, value_node = None):

--- a/ccorp/ruamel/yaml/include/__init__.py
+++ b/ccorp/ruamel/yaml/include/__init__.py
@@ -97,7 +97,6 @@ class YAML(ruamel.yaml.YAML):
 
     def fork(self):
         yaml = type(self)(typ=self.typ, pure=self.pure)
-        yaml.composer.anchors = self.composer.anchors
         return yaml
 
 


### PR DESCRIPTION
In ruamel.yaml >= 0.18.7, the `compose_document` method of the composer resets the `self.anchors` dictionary every time it is called (so on a new document start):

https://sourceforge.net/p/ruamel-yaml/code/ci/2ccda40f4274005ca52b7976e2d9666a66f9e5f9/tree/composer.py?diff=0bef9fa8b3c43637cd90ce3f2e299e81c2122128

This means that the line https://github.com/marsoloGit/ccorp_yaml_include/blob/163789cc516997e033ecc2f488eab2c075c7c66f/ccorp/ruamel/yaml/include/__init__.py#L100 doesn't actually do anything useful, since the fork's copy of the `anchors` dict gets reset and anchors added in the `!include` don't propagate to the top-level any more. I added a mechanism to instead update the parent `anchors` dict after the parsing of the included document is done.